### PR TITLE
Fix typo: CMB temperature unit (k → K)

### DIFF
--- a/notes/universe.tex
+++ b/notes/universe.tex
@@ -2024,7 +2024,7 @@ far-reaching consequences.
 
 The cosmic-microwave background (CMB) is microwave radiation pervading the universe
 with a spectrum that, to an astounding accuracy, is that of a blackbody with a
-temperature of $2.7255^\circ$~k . One of the most striking features of the CMB is its
+temperature of $2.7255^\circ$~K . One of the most striking features of the CMB is its
 isotropy\sidenote{The CMB is not, in fact, \emph{perfectly} isotropic, and nobody
 expected it to be. The relative temperature fluctuations of the CMB are at the
 level of $10^{-5}$ and encode important cosmological information.},
@@ -2032,7 +2032,7 @@ which we have in fact cited at the beginning of this section as one of the most
 compelling experimental evidences that the universe is isotropic at large scales.
 
 \keyfigures{CMB}{
-	Temperature: $2.7255^\circ$~k\\
+	Temperature: $2.7255^\circ$~K\\
 	Peak energy: $3.74 \times 10^{-4}$~eV\\
 	$\subcmb{n} \approx 410$~cm$^{-3}$\\
 	$\subcmb{\density} \approx 0.2606$~eV~cm$^{-3}$


### PR DESCRIPTION
Fixed typo in CMB temperature unit on page 41.

**Changes:**
- Line 2027: Changed `k` to `K` (Kelvin unit)
- Line 2035: Changed `k` to `K` (Kelvin unit)

The Kelvin unit should be uppercase K according to SI standards.

Closes #22