### PR TITLE
Fix two solar core typos in universe notes

### DIFF
--- a/notes/universe.tex
+++ b/notes/universe.tex
@@ -624,7 +624,7 @@ generating energy is the fusion of $H$ into $He$.
 	\input{figures/sun_standard_model.pgf}
 	\caption{Basic Sun characteristics according to the BS05 Sun standard model
   described in~\cite{2005ApJ...621L..85B}. According to the model, the temperature
-  at the center of the Sun is $1.55~^\circ$K, while the density is $150$~g~cm$^{-3}$.
+  at the center of the Sun is $1.55 \times 10^7~^\circ$K, while the density is $150$~g~cm$^{-3}$.
   The temperature and density approximately follow an exponential law across mos
   of the radial profile.}
     \label{fig:sun_standard_model}
@@ -776,7 +776,7 @@ which in our case is only about 0.1\% of that from the ideal gas law we have
 used---radiation pressure is just subdominant in a star with the mass of the
 Sun\sidenote{Note, however, that while the ideal gas pressure is proportional to
 the temperature, radiation pressure scales as $T^4$, and the ratio between the
-two goes like $T^3$: if the temperature in the core of teh Sun was just a mere
+two goes like $T^3$: if the temperature in the core of the Sun was just a mere
 order of magnitude larger, the radiation pressure would be dominant.}.
 
 In section~\ref{sec:white_dwarfs} we shall see that for \emph{degenerate} stars


### PR DESCRIPTION
## Summary
- fix the missing `\times 10^7` factor in the Sun core temperature caption
- fix the reported `teh` typo in the radiation-pressure sidenote

Closes #27
Closes #28

## Validation
- ran `git diff --check`
- TeX build not run locally because `pdflatex` is not installed in this environment